### PR TITLE
Rubygems pat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Publish Docker Image to GitHub Container Registry
-A GitHub Action which builds a Docker Image, from the latest release (git tag), and publishes it to GitHub Container Registry. 
+A GitHub Action which builds a Docker Image, from the latest release (git tag), and publishes it to GitHub Container Registry.
 ## Usage
 Add the following to `.github/workflows/publish-image.yml`
 
@@ -13,14 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Publish to GitHub Packages
-      uses: inforlife/publish-docker-image-to-github-container-registry-action
-@2021.1
+    - name: Publish to GitHub Container Registry
+      uses: inforlife/publish-docker-image-to-github-container-registry-action@2021.2
       with:
-        pat: ${{ secrets.CR_PAT }}
+        container_pat: ${{ secrets.CR_PAT }}
+        rubygems_pat: ${{ secrets.RR_PAT }}
+
 ```
 ## Secrets
-- **The `CR_PAT` (Container Registry Private Access Token) must be created and added to the Repo's secrets via GitHub UI.** The token should be unique for the repo and have `read:packages, repo, write:packages` permissions.
+**The following tokens must be created and added to the Repo's secrets via GitHub UI.**
+- `CR_PAT` (Container Registry Private Access Token). The token should be unique for the repo and have `read:packages, repo, write:packages` scopes.
+- `RR_PAT` (RubyGems Registry Private Access Token). The token should be unique for the repo and have `read:packages` scope. The token is needed only if the application has dependencies hosted at the [GitHub RubyGems registry](https://github.com/inforlife?tab=packages)
+
 ## Docker image
 This action creates the package `ghcr.io/<ORGANIZATION>/<REPOSITORY>:<RELEASE_TAG>`.
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -z "${INPUT_PAT}" ]; then
+if [ -z "${INPUT_CONTAINER_PAT}" ]; then
   echo "PAT not found. Add a Personal Access Token with `read:packages` & `read:packages` permissions to the repository's secrets and then `pat: ${{ secrets.CR_PAT }}` to the workflow file."
   exit 1
 fi
@@ -9,9 +9,9 @@ fi
 RELEASE_TAG=${GITHUB_REF:10}
 
 # login with new container registry url and PAT
-echo ${INPUT_PAT} | docker login ghcr.io -u ${GITHUB_REPOSITORY_OWNER} --password-stdin
+echo ${INPUT_CONTAINER_PAT} | docker login ghcr.io -u ${GITHUB_REPOSITORY_OWNER} --password-stdin
 # new container registry urls added
-docker build --build-arg RELEASE_TAG=${RELEASE_TAG} --tag ghcr.io/${GITHUB_REPOSITORY}:${RELEASE_TAG} --cache-from ghcr.io/${INPUT_ORGANIZATION}/${REPO}:latest .
-docker push ghcr.io/${GITHUB_REPOSITORY}:${RELEASE_TAG}
+docker build --build-arg RELEASE_TAG=${RELEASE_TAG} --build-arg RR_PAT=${INPUT_RUBYGEMS_PAT} --tag ghcr.io/inforlife/${GITHUB_REPOSITORY}:${RELEASE_TAG} --cache-from ghcr.io/inforlife/${REPO}:latest .
+docker push ghcr.io/inforlife/${GITHUB_REPOSITORY}:${RELEASE_TAG}
 
 docker logout


### PR DESCRIPTION
This PR adds the RR_PAT token needed to authenticate with Bundler against the GitHub RubyGems registry where company gems (i.e. jumpstart) are hosted.